### PR TITLE
Allow injecting command args/options into `__invoke()`

### DIFF
--- a/src/InvokableServiceCommand.php
+++ b/src/InvokableServiceCommand.php
@@ -36,15 +36,11 @@ abstract class InvokableServiceCommand extends Command implements ServiceSubscri
                             return null;
                         }
 
-                        if (!$type instanceof \ReflectionNamedType) {
+                        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
                             return null;
                         }
 
                         $name = $type->getName();
-
-                        if ($type->isBuiltin()) {
-                            throw new \LogicException(\sprintf('"%s::__invoke()" cannot accept built-in parameter: $%s (%s).', static::class, $parameter->getName(), $name));
-                        }
 
                         if (\is_a($name, InputInterface::class, true)) {
                             return null;

--- a/tests/Fixture/Command/ServiceCommand.php
+++ b/tests/Fixture/Command/ServiceCommand.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Console\Tests\Fixture\Command;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\StyleInterface;
@@ -16,8 +17,21 @@ use Zenstruck\Console\IO;
  */
 final class ServiceCommand extends InvokableServiceCommand
 {
-    public function __invoke(IO $io, InputInterface $input, OutputInterface $output, StyleInterface $style, $none, LoggerInterface $logger, ?RouterInterface $router = null, ?Table $optional = null): void
-    {
+    public function __invoke(
+        IO $io,
+        InputInterface $input,
+        OutputInterface $output,
+        StyleInterface $style,
+        $none,
+        $arg1,
+        string $arg2,
+        $opt1,
+        bool $opt2,
+        string $env,
+        LoggerInterface $logger,
+        ?RouterInterface $router = null,
+        ?Table $optional = null
+    ): void {
         $io->comment(\sprintf('IO: %s', \get_debug_type($io)));
         $io->comment(\sprintf('InputInterface: %s', \get_debug_type($input)));
         $io->comment(\sprintf('OutputInterface: %s', \get_debug_type($output)));
@@ -27,6 +41,11 @@ final class ServiceCommand extends InvokableServiceCommand
         $io->comment(\sprintf('RouterInterface: %s', \get_debug_type($router)));
         $io->comment(\sprintf('Table: %s', \get_debug_type($optional)));
         $io->comment(\sprintf('Parameter environment: %s', $this->parameter('kernel.environment')));
+        $io->comment(\sprintf('arg1: %s', \var_export($arg1, true)));
+        $io->comment(\sprintf('arg2: %s', \var_export($arg2, true)));
+        $io->comment(\sprintf('opt1: %s', \var_export($opt1, true)));
+        $io->comment(\sprintf('opt2: %s', \var_export($opt2, true)));
+        $io->comment(\sprintf('env: %s', \var_export($env, true)));
 
         $io->success('done!');
     }
@@ -34,5 +53,15 @@ final class ServiceCommand extends InvokableServiceCommand
     public static function getDefaultName(): string
     {
         return 'service-command';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('arg1', InputArgument::REQUIRED)
+            ->addArgument('arg2', InputArgument::REQUIRED)
+            ->addOption('opt1')
+            ->addOption('opt2')
+        ;
     }
 }

--- a/tests/Integration/EventListener/CommandSummarySubscriberTest.php
+++ b/tests/Integration/EventListener/CommandSummarySubscriberTest.php
@@ -5,7 +5,6 @@ namespace Zenstruck\Console\Tests\Integration\EventListener;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Console\EventListener\CommandSummarySubscriber;
 use Zenstruck\Console\Test\InteractsWithConsole;
-use Zenstruck\Console\Tests\Fixture\Command\ServiceCommand;
 use Zenstruck\Console\Tests\Fixture\EventListener\CustomCommandSummarySubscriber;
 
 /**
@@ -24,7 +23,7 @@ final class CommandSummarySubscriberTest extends KernelTestCase
 
         self::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new CommandSummarySubscriber());
 
-        $this->executeConsoleCommand(ServiceCommand::class)
+        $this->executeConsoleCommand('service-command foo bar')
             ->assertSuccessful()
             ->assertOutputContains('IO: ')
             ->assertOutputContains('Duration: ')
@@ -41,7 +40,7 @@ final class CommandSummarySubscriberTest extends KernelTestCase
 
         self::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new CustomCommandSummarySubscriber());
 
-        $this->executeConsoleCommand(ServiceCommand::class)
+        $this->executeConsoleCommand('service-command foo bar')
             ->assertSuccessful()
             ->assertOutputContains('IO: ')
             ->assertOutputNotContains('Duration: ')

--- a/tests/Integration/InvokableServiceCommandTest.php
+++ b/tests/Integration/InvokableServiceCommandTest.php
@@ -9,7 +9,6 @@ use Zenstruck\Console\IO;
 use Zenstruck\Console\Test\InteractsWithConsole;
 use Zenstruck\Console\Test\TestInput;
 use Zenstruck\Console\Test\TestOutput;
-use Zenstruck\Console\Tests\Fixture\Command\ServiceCommand;
 use Zenstruck\Console\Tests\Fixture\Command\ServiceSubscriberTraitCommand;
 
 /**
@@ -24,7 +23,7 @@ final class InvokableServiceCommandTest extends KernelTestCase
      */
     public function can_auto_inject_services_into_invoke(): void
     {
-        $this->executeConsoleCommand(ServiceCommand::class)
+        $this->executeConsoleCommand('service-command foo bar --opt2')
             ->assertSuccessful()
             ->assertOutputContains(\sprintf('IO: %s', IO::class))
             ->assertOutputContains(\sprintf('InputInterface: %s', TestInput::class))
@@ -35,6 +34,11 @@ final class InvokableServiceCommandTest extends KernelTestCase
             ->assertOutputContains(\sprintf('RouterInterface: %s', Router::class))
             ->assertOutputContains('Table: null')
             ->assertOutputContains('Parameter environment: test')
+            ->assertOutputContains("arg1: 'foo'")
+            ->assertOutputContains("arg2: 'bar'")
+            ->assertOutputContains("env: 'test'")
+            ->assertOutputContains('opt1: false')
+            ->assertOutputContains('opt2: true')
         ;
     }
 

--- a/tests/Unit/InvokableTest.php
+++ b/tests/Unit/InvokableTest.php
@@ -31,19 +31,45 @@ final class InvokableTest extends TestCase
     {
         TestCommand::for(
             new class() extends InvokableCommand {
-                public function __invoke(IO $io, InputInterface $input, OutputInterface $output, StyleInterface $style, $none, ?string $optional = null)
-                {
+                public function __invoke(
+                    IO $io,
+                    InputInterface $input,
+                    OutputInterface $output,
+                    StyleInterface $style,
+                    $none,
+                    $arg1,
+                    string $arg2,
+                    $opt1,
+                    bool $opt2,
+                    ?string $optional = null
+                ) {
                     $io->comment(\sprintf('IO: %s', \get_class($io)));
                     $io->comment(\sprintf('$this->io(): %s', \get_class($this->io())));
                     $io->comment(\sprintf('InputInterface: %s', \get_class($input)));
                     $io->comment(\sprintf('OutputInterface: %s', \get_class($output)));
                     $io->comment(\sprintf('StyleInterface: %s', \get_class($style)));
                     $io->comment(\sprintf('none: %s', \get_class($none)));
+                    $io->comment(\sprintf('arg1: %s', \var_export($arg1, true)));
+                    $io->comment(\sprintf('arg2: %s', \var_export($arg2, true)));
+                    $io->comment(\sprintf('opt1: %s', \var_export($opt1, true)));
+                    $io->comment(\sprintf('opt2: %s', \var_export($opt2, true)));
 
                     $io->success('done!');
                 }
+
+                protected function configure(): void
+                {
+                    parent::configure();
+
+                    $this
+                        ->addArgument('arg1')
+                        ->addArgument('arg2')
+                        ->addOption('opt1')
+                        ->addOption('opt2')
+                    ;
+                }
             })
-            ->execute()
+            ->execute('foo bar --opt2')
             ->assertSuccessful()
             ->assertOutputContains(\sprintf('IO: %s', IO::class))
             ->assertOutputContains(\sprintf('$this->io(): %s', IO::class))
@@ -51,6 +77,10 @@ final class InvokableTest extends TestCase
             ->assertOutputContains(\sprintf('OutputInterface: %s', TestOutput::class))
             ->assertOutputContains(\sprintf('StyleInterface: %s', IO::class))
             ->assertOutputContains(\sprintf('none: %s', IO::class))
+            ->assertOutputContains("arg1: 'foo'")
+            ->assertOutputContains("arg2: 'bar'")
+            ->assertOutputContains('opt1: false')
+            ->assertOutputContains('opt2: true')
         ;
     }
 


### PR DESCRIPTION
```php
class MyCommand extends \Symfony\Component\Console\Command\Command
{
    use Invokable;

    // $username/$roles are the argument/option defined below
    public function __invoke(IO $io, string $username, array $roles)
    {
        $io->success('created.');

        // even if you don't inject IO, it's available as a method:
        $this->io(); // IO
    }

    public function configure(): void
    {
        $this
            ->addArgument('username', InputArgument::REQUIRED)
            ->addOption('roles', mode: InputOption::VALUE_IS_ARRAY)
        ;
    }
}
```