### PR TITLE
Define opts/args on `__invoke()` params with `Argument|Option` attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zenstruck/console-extra",
-    "description": "Supercharge your Symfony console commands!",
+    "description": "A modular set of features to reduce configuration boilerplate for your Symfony commands.",
     "homepage": "https://github.com/zenstruck/console-extra",
     "type": "library",
     "license": "MIT",

--- a/src/Attribute/Argument.php
+++ b/src/Attribute/Argument.php
@@ -7,14 +7,14 @@ use Symfony\Component\Console\Input\InputArgument;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 final class Argument
 {
     /**
      * @see InputArgument::__construct()
      */
     public function __construct(
-        private string $name,
+        public ?string $name = null,
         private ?int $mode = null,
         private string $description = '',
         private string|bool|int|float|array|null $default = null,
@@ -24,10 +24,54 @@ final class Argument
     /**
      * @internal
      *
+     * @return mixed[]|null
+     */
+    public static function parseParameter(\ReflectionParameter $parameter): ?array
+    {
+        if (!$attributes = $parameter->getAttributes(self::class)) {
+            return null;
+        }
+
+        if (\count($attributes) > 1) {
+            throw new \LogicException(\sprintf('%s cannot be repeated when used as a parameter attribute.', self::class));
+        }
+
+        /** @var self $value */
+        $value = $attributes[0]->newInstance();
+        $value->name = $value->name ?? $parameter->name;
+
+        if ($value->mode) {
+            throw new \LogicException(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', self::class));
+        }
+
+        if ($value->default) {
+            throw new \LogicException(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', self::class));
+        }
+
+        $value->mode = $parameter->isDefaultValueAvailable() || $parameter->allowsNull() ? InputArgument::OPTIONAL : InputArgument::REQUIRED;
+
+        if ($parameter->getType() instanceof \ReflectionNamedType && 'array' === $parameter->getType()->getName()) {
+            $value->mode |= InputArgument::IS_ARRAY;
+        }
+
+        if ($parameter->isDefaultValueAvailable()) {
+            $value->default = $parameter->getDefaultValue();
+        }
+
+        return $value->values();
+    }
+
+    /**
+     * @internal
+     *
      * @return mixed[]
      */
     public function values(): array
     {
+        if (!$this->name) {
+            throw new \LogicException(\sprintf('A $name is required when using %s as a command class attribute.', self::class));
+        }
+
         return [$this->name, $this->mode, $this->description, $this->default];
     }
 }

--- a/src/Attribute/Option.php
+++ b/src/Attribute/Option.php
@@ -7,14 +7,14 @@ use Symfony\Component\Console\Input\InputOption;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 final class Option
 {
     /**
      * @see InputOption::__construct()
      */
     public function __construct(
-        private string $name,
+        public ?string $name = null,
         private string|array|null $shortcut = null,
         private ?int $mode = null,
         private string $description = '',
@@ -25,10 +25,56 @@ final class Option
     /**
      * @internal
      *
+     * @return mixed[]|null
+     */
+    public static function parseParameter(\ReflectionParameter $parameter): ?array
+    {
+        if (!$attributes = $parameter->getAttributes(self::class)) {
+            return null;
+        }
+
+        if (\count($attributes) > 1) {
+            throw new \LogicException(\sprintf('%s cannot be repeated when used as a parameter attribute.', self::class));
+        }
+
+        /** @var self $value */
+        $value = $attributes[0]->newInstance();
+        $value->name = $value->name ?? $parameter->name;
+
+        if ($value->mode) {
+            throw new \LogicException(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', self::class));
+        }
+
+        if ($value->default) {
+            throw new \LogicException(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', self::class));
+        }
+
+        $name = $parameter->getType() instanceof \ReflectionNamedType ? $parameter->getType()->getName() : null;
+
+        $value->mode = match ($name) {
+            'array' => InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+            'bool' => \defined(InputOption::class.'::VALUE_NEGATABLE') && $parameter->allowsNull() ? InputOption::VALUE_NEGATABLE : InputOption::VALUE_NONE,
+            default => InputOption::VALUE_REQUIRED,
+        };
+
+        if ($value->mode ^ InputOption::VALUE_NONE && $parameter->isDefaultValueAvailable()) {
+            $value->default = $parameter->getDefaultValue();
+        }
+
+        return $value->values();
+    }
+
+    /**
+     * @internal
+     *
      * @return mixed[]
      */
     public function values(): array
     {
+        if (!$this->name) {
+            throw new \LogicException(\sprintf('A $name is required when using %s as a command class attribute.', self::class));
+        }
+
         return [$this->name, $this->shortcut, $this->mode, $this->description, $this->default];
     }
 }

--- a/src/ConfigureWithAttributes.php
+++ b/src/ConfigureWithAttributes.php
@@ -12,6 +12,10 @@ trait ConfigureWithAttributes
 {
     protected function configure(): void
     {
+        if (\PHP_VERSION_ID < 80000) {
+            throw new \LogicException(\sprintf('PHP 8+ required to use %s.', ConfigureWithAttributes::class));
+        }
+
         $class = new \ReflectionClass($this);
 
         foreach ($class->getAttributes(Argument::class) as $attribute) {
@@ -20,6 +24,24 @@ trait ConfigureWithAttributes
 
         foreach ($class->getAttributes(Option::class) as $attribute) {
             $this->addOption(...$attribute->newInstance()->values());
+        }
+
+        try {
+            $parameters = (new \ReflectionClass(static::class))->getMethod('__invoke')->getParameters();
+        } catch (\ReflectionException $e) {
+            return; // not using Invokable
+        }
+
+        foreach ($parameters as $parameter) {
+            if ($args = Argument::parseParameter($parameter)) {
+                $this->addArgument(...$args);
+
+                continue;
+            }
+
+            if ($args = Option::parseParameter($parameter)) {
+                $this->addOption(...$args);
+            }
         }
     }
 }

--- a/src/Invokable.php
+++ b/src/Invokable.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Zenstruck\Callback;
 use Zenstruck\Callback\Argument;
 use Zenstruck\Callback\Parameter;
+use Zenstruck\Console\Attribute\Argument as ConsoleArgument;
+use Zenstruck\Console\Attribute\Option;
 
 /**
  * Makes your command "invokable" to reduce boilerplate.
@@ -63,12 +65,20 @@ trait Invokable
                     );
                 }
 
-                if ((!$type || $type->isBuiltin()) && $input->hasArgument($parameter->name)) {
-                    return $input->getArgument($parameter->name);
-                }
+                if (!$type || $type->isBuiltin()) {
+                    $name = $parameter->name;
 
-                if ((!$type || $type->isBuiltin()) && $input->hasOption($parameter->name)) {
-                    return $input->getOption($parameter->name);
+                    if (\PHP_VERSION_ID >= 80000 && $attr = $parameter->getAttributes(ConsoleArgument::class)[0] ?? $parameter->getAttributes(Option::class)[0] ?? null) {
+                        $name = $attr->newInstance()->name ?? $name;
+                    }
+
+                    if ($input->hasArgument($name)) {
+                        return $input->getArgument($name);
+                    }
+
+                    if ($input->hasOption($name)) {
+                        return $input->getOption($name);
+                    }
                 }
 
                 return Parameter::union(

--- a/tests/Unit/AttributesConfigureTest.php
+++ b/tests/Unit/AttributesConfigureTest.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Zenstruck\Console\Attribute\Argument;
 use Zenstruck\Console\Attribute\Option;
 use Zenstruck\Console\ConfigureWithAttributes;
+use Zenstruck\Console\Invokable;
+use Zenstruck\Console\Test\TestCommand;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -19,10 +21,11 @@ final class AttributesConfigureTest extends TestCase
 {
     /**
      * @test
+     * @dataProvider attributeCommandProvider
      */
-    public function parse_arguments_and_options(): void
+    public function parse_arguments_and_options(string $class): void
     {
-        $command = new WithAttributesCommand();
+        $command = new $class();
         $definition = $command->getDefinition();
 
         $arg = $definition->getArgument('arg1');
@@ -77,6 +80,255 @@ final class AttributesConfigureTest extends TestCase
         $this->assertSame('o', $option->getShortcut());
         $this->assertTrue($option->isValueRequired());
     }
+
+    public static function attributeCommandProvider(): iterable
+    {
+        yield [WithClassAttributesCommand::class];
+        yield [WithParameterAttributesCommand::class];
+    }
+
+    /**
+     * @test
+     */
+    public function argument_attribute_name_required_when_using_on_class(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('A $name is required when using %s as a command class attribute.', Argument::class));
+
+        new ArgumentClassAttributeMissingName();
+    }
+
+    /**
+     * @test
+     */
+    public function option_attribute_name_required_when_using_on_class(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('A $name is required when using %s as a command class attribute.', Option::class));
+
+        new OptionClassAttributeMissingName();
+    }
+
+    /**
+     * @test
+     */
+    public function negatable_parameter_attribute_options(): void
+    {
+        if (!\defined(InputOption::class.'::VALUE_NEGATABLE')) {
+            $this->markTestSkipped('Negatable arguments not available.');
+        }
+
+        $command = TestCommand::for(
+            new class() extends Command {
+                use ConfigureWithAttributes, Invokable;
+
+                public static function getDefaultName(): ?string
+                {
+                    return 'command';
+                }
+
+                public function __invoke(
+                    #[Option] ?bool $foo
+                ): void {
+                    $this->io()->writeln(\sprintf('foo: %s', \var_export($foo, true)));
+                }
+            }
+        );
+
+        $command->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('foo: NULL')
+        ;
+
+        $command->execute('--foo')
+            ->assertSuccessful()
+            ->assertOutputContains('foo: true')
+        ;
+
+        $command->execute('--no-foo')
+            ->assertSuccessful()
+            ->assertOutputContains('foo: false')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function can_customize_argument_and_option_names_via_parameter_attribute(): void
+    {
+        $command = TestCommand::for(
+            new class() extends Command {
+                use ConfigureWithAttributes, Invokable;
+
+                public static function getDefaultName(): ?string
+                {
+                    return 'command';
+                }
+
+                public function __invoke(
+                    #[Argument('custom-foo')] ?string $foo,
+                    #[Option('custom-bar')] bool $bar
+                ): void {
+                    $this->io()->writeln(\sprintf('foo: %s', \var_export($foo, true)));
+                    $this->io()->writeln(\sprintf('bar: %s', \var_export($bar, true)));
+                }
+            }
+        );
+
+        $command->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('foo: NULL')
+            ->assertOutputContains('bar: false')
+        ;
+
+        $command->execute('value --custom-bar')
+            ->assertSuccessful()
+            ->assertOutputContains("foo: 'value'")
+            ->assertOutputContains('bar: true')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_use_mode_with_argument_as_parameter_attribute(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', Argument::class));
+
+        new class() extends Command {
+            use ConfigureWithAttributes, Invokable;
+
+            public static function getDefaultName(): ?string
+            {
+                return 'command';
+            }
+
+            public function __invoke(
+                #[Argument(mode: InputArgument::REQUIRED)] $foo
+            ): void {
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_use_default_with_argument_as_parameter_attribute(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', Argument::class));
+
+        new class() extends Command {
+            use ConfigureWithAttributes, Invokable;
+
+            public static function getDefaultName(): ?string
+            {
+                return 'command';
+            }
+
+            public function __invoke(
+                #[Argument(default: true)] $foo
+            ): void {
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_use_mode_with_option_as_parameter_attribute(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', Option::class));
+
+        new class() extends Command {
+            use ConfigureWithAttributes, Invokable;
+
+            public static function getDefaultName(): ?string
+            {
+                return 'command';
+            }
+
+            public function __invoke(
+                #[Option(mode: InputArgument::REQUIRED)] $foo
+            ): void {
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_use_default_with_option_as_parameter_attribute(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', Option::class));
+
+        new class() extends Command {
+            use ConfigureWithAttributes, Invokable;
+
+            public static function getDefaultName(): ?string
+            {
+                return 'command';
+            }
+
+            public function __invoke(
+                #[Option(default: true)] $foo
+            ): void {
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    public function option_not_repeatable_when_used_on_parameter(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('%s cannot be repeated when used as a parameter attribute.', Option::class));
+
+        new class() extends Command {
+            use ConfigureWithAttributes, Invokable;
+
+            public static function getDefaultName(): ?string
+            {
+                return 'command';
+            }
+
+            public function __invoke(
+                #[Option]
+                #[Option]
+                $foo
+            ): void {
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    public function argument_not_repeatable_when_used_on_parameter(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('%s cannot be repeated when used as a parameter attribute.', Argument::class));
+
+        new class() extends Command {
+            use ConfigureWithAttributes, Invokable;
+
+            public static function getDefaultName(): ?string
+            {
+                return 'command';
+            }
+
+            public function __invoke(
+                #[Argument]
+                #[Argument]
+                $foo
+            ): void {
+            }
+        };
+    }
 }
 
 #[Argument('arg1', InputArgument::REQUIRED, 'First argument is required')]
@@ -87,7 +339,51 @@ final class AttributesConfigureTest extends TestCase
 #[Option('option2', null, InputOption::VALUE_REQUIRED, 'Second option (value required)')]
 #[Option('option3', null, InputOption::VALUE_REQUIRED, 'Third option with default value', 'default')]
 #[Option('option4', 'o', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Fourth option is an array with a shortcut (-o)')]
-class WithAttributesCommand extends Command
+class WithClassAttributesCommand extends Command
+{
+    use ConfigureWithAttributes;
+}
+
+class WithParameterAttributesCommand extends Command
+{
+    use ConfigureWithAttributes, Invokable;
+
+    public function __invoke(
+        #[Argument(description: 'First argument is required')]
+        string $arg1,
+
+        #[Argument(description: 'Second argument is optional')]
+        ?string $arg2 = null,
+
+        #[Argument(description: 'Third argument is optional with a default value')]
+        string $arg3 = 'default',
+
+        #[Argument('arg4', description: 'Fourth argument is an optional array')]
+        array $foo = [],
+
+        #[Option(description: 'First option (no value)')]
+        bool $option1 = false,
+
+        #[Option(description: 'Second option (value required)')]
+        ?string $option2 = null,
+
+        #[Option(description: 'Third option with default value')]
+        string $option3 = 'default',
+
+        #[Option('option4', shortcut: 'o', description: 'Fourth option is an array with a shortcut (-o)')]
+        array $bar = []
+    ) {
+    }
+}
+
+#[Argument]
+class ArgumentClassAttributeMissingName extends Command
+{
+    use ConfigureWithAttributes;
+}
+
+#[Option]
+class OptionClassAttributeMissingName extends Command
 {
     use ConfigureWithAttributes;
 }


### PR DESCRIPTION
Fixes #26.

**TODO:**
- [x] complete tests
- [x] docs