### PR TITLE
Deprecate `ConfigureWithDocblocks` on PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ class CreateUserCommand extends Command
 
 ### `ConfigureWithDocblocks`
 
+> **Note**
+> This trait is deprecated when using with PHP 8+ and will be removed in 2.0.
+> Use [`ConfigureWithAttributes`](#configurewithattributes) instead.
+
 Use this trait to allow your command to be configured by your command class' docblock.
 `phpdocumentor/reflection-docblock` is required for this feature
 (`composer install phpdocumentor/reflection-docblock`).

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": ">=7.4",
         "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/string": "^5.0|^6.0",
         "zenstruck/callback": "^1.4.2"

--- a/src/Configuration/DocblockConfiguration.php
+++ b/src/Configuration/DocblockConfiguration.php
@@ -7,6 +7,8 @@ use phpDocumentor\Reflection\DocBlockFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Zenstruck\Console\ConfigureWithAttributes;
+use Zenstruck\Console\ConfigureWithDocblocks;
 
 use function Symfony\Component\String\u;
 
@@ -38,6 +40,10 @@ final class DocblockConfiguration
     {
         $this->class = new \ReflectionClass($class);
         $this->docblock = self::factory()->create($this->class->getDocComment() ?: ' '); // hack to allow empty docblock
+
+        if (\PHP_VERSION_ID >= 80000) {
+            trigger_deprecation('zenstruck/console-extra', '1.1', 'The %s trait is deprecated and will be removed in 2.0. Use %s instead.', ConfigureWithDocblocks::class, ConfigureWithAttributes::class);
+        }
     }
 
     /**

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -17,7 +17,7 @@ use Zenstruck\Console\Test\TestCommand;
  *
  * @requires PHP 8
  */
-final class AttributesConfigureTest extends TestCase
+final class ConfigureWithAttributesTest extends TestCase
 {
     /**
      * @test

--- a/tests/Unit/ConfigureWithDocblocksTest.php
+++ b/tests/Unit/ConfigureWithDocblocksTest.php
@@ -9,6 +9,8 @@ use Zenstruck\Console\Tests\Fixture\Command\DocblockCommand;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @group legacy
  */
 final class ConfigureWithDocblocksTest extends TestCase
 {

--- a/tests/Unit/ConfigureWithDocblocksTest.php
+++ b/tests/Unit/ConfigureWithDocblocksTest.php
@@ -10,7 +10,7 @@ use Zenstruck\Console\Tests\Fixture\Command\DocblockCommand;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class DocblockConfigureTest extends TestCase
+final class ConfigureWithDocblocksTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
V2 will require PHP 8 and this trait will be dropped in favour of `ConfigureWithAttributes`.

Closes #28.