### PR TITLE
feat: drop-support of php < 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,17 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "symfony/console": "^4.4|^5.0|^6.0",
         "symfony/deprecation-contracts": "^2.2|^3.0",
-        "symfony/polyfill-php80": "^1.15",
         "symfony/string": "^5.0|^6.0",
         "zenstruck/callback": "^1.4.2"
     },
     "require-dev": {
-        "phpdocumentor/reflection-docblock": "^5.2",
-        "phpstan/phpstan": "^1.4",
+        "phpdocumentor/reflection-docblock": "^5.3",
+        "phpstan/phpstan": "^1.8",
         "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-        "symfony/phpunit-bridge": "^5.3",
+        "symfony/phpunit-bridge": "^6.0",
         "symfony/process": "^4.4|^5.0|^6.0",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
         "zenstruck/console-test": "^1.3"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/Attribute/Argument.php
 
 		-
-			message: "#^Property Zenstruck\\\\Console\\\\Attribute\\\\Argument\\:\\:\\$default type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Attribute/Argument.php
-
-		-
 			message: "#^Method Zenstruck\\\\Console\\\\Attribute\\\\Option\\:\\:__construct\\(\\) has parameter \\$default with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Attribute/Option.php
@@ -21,12 +16,7 @@ parameters:
 			path: src/Attribute/Option.php
 
 		-
-			message: "#^Property Zenstruck\\\\Console\\\\Attribute\\\\Option\\:\\:\\$default type has no value type specified in iterable type array\\.$#"
+			message: "#^Method Zenstruck\\\\Console\\\\IO\\:\\:getParameterOption\\(\\) has parameter \\$default with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Attribute/Option.php
-
-		-
-			message: "#^Property Zenstruck\\\\Console\\\\Attribute\\\\Option\\:\\:\\$shortcut type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Attribute/Option.php
+			path: src/IO.php
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/bin/.phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
-         failOnWarning="true"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
-        <env name="KERNEL_CLASS" value="Zenstruck\Console\Tests\Fixture\Kernel" />
-        <env name="SHELL_VERBOSITY" value="-1"/>
-        <env name="COLUMNS" value="120" />
-    </php>
-
-    <testsuites>
-        <testsuite name="zenstruck/console-extra Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
+         failOnWarning="true">
+  <coverage>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+    <env name="KERNEL_CLASS" value="Zenstruck\Console\Tests\Fixture\Kernel"/>
+    <env name="SHELL_VERBOSITY" value="-1"/>
+    <env name="COLUMNS" value="120"/>
+  </php>
+  <testsuites>
+    <testsuite name="zenstruck/console-extra Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/bin/.phpunit/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"

--- a/src/CommandRunner.php
+++ b/src/CommandRunner.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Console;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\StringInput;
@@ -73,6 +74,7 @@ final class CommandRunner
 
     /**
      * @param string[] $inputs Interactive inputs to use for the command
+     * @throws ExceptionInterface
      */
     public function run(array $inputs = []): int
     {

--- a/src/CommandRunner.php
+++ b/src/CommandRunner.php
@@ -74,6 +74,7 @@ final class CommandRunner
 
     /**
      * @param string[] $inputs Interactive inputs to use for the command
+     *
      * @throws ExceptionInterface
      */
     public function run(array $inputs = []): int

--- a/src/Configuration/DocblockConfiguration.php
+++ b/src/Configuration/DocblockConfiguration.php
@@ -35,6 +35,7 @@ final class DocblockConfiguration
 
     /**
      * @param class-string<T> $class
+     *
      * @throws \ReflectionException
      */
     private function __construct(string $class)

--- a/src/Configuration/DocblockConfiguration.php
+++ b/src/Configuration/DocblockConfiguration.php
@@ -35,6 +35,7 @@ final class DocblockConfiguration
 
     /**
      * @param class-string<T> $class
+     * @throws \ReflectionException
      */
     private function __construct(string $class)
     {

--- a/src/ConfigureWithDocblocks.php
+++ b/src/ConfigureWithDocblocks.php
@@ -21,8 +21,10 @@ use Zenstruck\Console\Configuration\DocblockConfiguration;
  * Examples:
  *
  * @command app:my:command
+ *
  * @alias alias1
  * @alias alias2
+ *
  * @hidden
  *
  * @argument arg1 First argument is required

--- a/src/IO.php
+++ b/src/IO.php
@@ -96,20 +96,16 @@ class IO extends SymfonyStyle implements InputInterface
 
     /**
      * Alias for {@see getArgument()}.
-     *
-     * @return mixed
      */
-    public function argument(string $name)
+    public function argument(string $name): mixed
     {
         return $this->getArgument($name);
     }
 
     /**
      * Alias for {@see getOption()}.
-     *
-     * @return mixed
      */
-    public function option(string $name)
+    public function option(string $name): mixed
     {
         return $this->getOption($name);
     }
@@ -121,21 +117,16 @@ class IO extends SymfonyStyle implements InputInterface
 
     /**
      * @param string|string[] $values
-     * @param bool            $onlyParams
      */
-    public function hasParameterOption($values, $onlyParams = false): bool
+    public function hasParameterOption($values, bool $onlyParams = false): bool
     {
         return $this->input->hasParameterOption($values, $onlyParams);
     }
 
     /**
      * @param string|string[] $values
-     * @param mixed           $default
-     * @param bool            $onlyParams
-     *
-     * @return mixed
      */
-    public function getParameterOption($values, $default = false, $onlyParams = false)
+    public function getParameterOption(string|array $values, mixed $default = false, bool $onlyParams = false): mixed
     {
         return $this->input->getParameterOption($values, $default, $onlyParams);
     }
@@ -158,29 +149,17 @@ class IO extends SymfonyStyle implements InputInterface
         return $this->input->getArguments();
     }
 
-    /**
-     * @param string $name
-     *
-     * @return mixed
-     */
-    public function getArgument($name)
+    public function getArgument(string $name): mixed
     {
         return $this->input->getArgument($name);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $value
-     */
-    public function setArgument($name, $value): void
+    public function setArgument(string $name, mixed $value): void
     {
         $this->input->setArgument($name, $value);
     }
 
-    /**
-     * @param string $name
-     */
-    public function hasArgument($name): bool
+    public function hasArgument(string $name): bool
     {
         return $this->input->hasArgument($name);
     }
@@ -193,29 +172,17 @@ class IO extends SymfonyStyle implements InputInterface
         return $this->input->getOptions();
     }
 
-    /**
-     * @param string $name
-     *
-     * @return mixed
-     */
-    public function getOption($name)
+    public function getOption(string $name): mixed
     {
         return $this->input->getOption($name);
     }
 
-    /**
-     * @param string $name
-     * @param mixed  $value
-     */
-    public function setOption($name, $value): void
+    public function setOption(string $name, mixed $value): void
     {
         $this->input->setOption($name, $value);
     }
 
-    /**
-     * @param string $name
-     */
-    public function hasOption($name): bool
+    public function hasOption(string $name): bool
     {
         return $this->input->hasOption($name);
     }
@@ -225,10 +192,7 @@ class IO extends SymfonyStyle implements InputInterface
         return $this->input->isInteractive();
     }
 
-    /**
-     * @param bool $interactive
-     */
-    public function setInteractive($interactive): void
+    public function setInteractive(bool $interactive): void
     {
         $this->input->setInteractive($interactive);
     }

--- a/src/InvokableServiceCommand.php
+++ b/src/InvokableServiceCommand.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Console;
 
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\Console\Command\Command;
@@ -98,9 +99,10 @@ abstract class InvokableServiceCommand extends Command implements ServiceSubscri
     }
 
     /**
-     * @return mixed
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    final protected function parameter(string $name)
+    final protected function parameter(string $name): mixed
     {
         return $this->container()->get(ParameterBagInterface::class)->get($name);
     }

--- a/src/RunsCommands.php
+++ b/src/RunsCommands.php
@@ -14,7 +14,7 @@ trait RunsCommands
      *                                                     MyCommand::class
      *                                                     ['command' => 'my:command', 'arg' => 'value']
      */
-    protected function runCommand($cli, array $inputs = []): int
+    protected function runCommand(array|string $cli, array $inputs = []): int
     {
         if (!$this instanceof Command || !\method_exists($this, 'io')) {
             throw new \LogicException(\sprintf('"%s" can only be used with "%s" commands.', __TRAIT__, Invokable::class));

--- a/src/RunsProcesses.php
+++ b/src/RunsProcesses.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Console;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Process\Process;
 
@@ -12,9 +13,9 @@ use Symfony\Component\Process\Process;
 trait RunsProcesses
 {
     /**
-     * @param string[]|string|Process $process
+     * @param string|Process|string[] $process
      */
-    protected function runProcess($process): Process
+    protected function runProcess(array|Process|string $process): Process
     {
         if (!\class_exists(Process::class)) {
             throw new \LogicException('symfony/process required: composer require symfony/process');
@@ -29,7 +30,7 @@ trait RunsProcesses
         }
 
         $commandLine = $process->getCommandLine();
-        $maxLength = \min((new Terminal())->getWidth(), IO::MAX_LINE_LENGTH) - 48;  // account for prefix/decoration length
+        $maxLength = \min((new Terminal())->getWidth(), SymfonyStyle::MAX_LINE_LENGTH) - 48;  // account for prefix/decoration length
         $last = null;
 
         if (\mb_strlen($commandLine) > $maxLength) {

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -7,6 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Zenstruck\Console\Tests\Fixture\Command\ServiceCommand;
 use Zenstruck\Console\Tests\Fixture\Command\ServiceSubscriberTraitCommand;
 
@@ -22,18 +23,19 @@ final class Kernel extends BaseKernel
         yield new FrameworkBundle();
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $c->register(ServiceCommand::class)->setAutowired(true)->setAutoconfigured(true);
-        $c->register(ServiceSubscriberTraitCommand::class)->setAutowired(true)->setAutoconfigured(true);
+        $container->register(ServiceCommand::class)->setAutowired(true)->setAutoconfigured(true);
+        $container->register(ServiceSubscriberTraitCommand::class)->setAutowired(true)->setAutoconfigured(true);
 
-        $c->loadFromExtension('framework', [
+        $container->loadFromExtension('framework', [
             'secret' => 'S3CRET',
+            'http_method_override' => false,
             'test' => true,
         ]);
     }
 
-    protected function configureRoutes($routes): void
+    protected function configureRoutes(RoutingConfigurator $routes): void
     {
         // TODO: Implement configureRoutes() method.
     }

--- a/tests/Integration/EventListener/CommandSummarySubscriberTest.php
+++ b/tests/Integration/EventListener/CommandSummarySubscriberTest.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Console\Tests\Integration\EventListener;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Zenstruck\Console\EventListener\CommandSummarySubscriber;
 use Zenstruck\Console\Test\InteractsWithConsole;
 use Zenstruck\Console\Tests\Fixture\EventListener\CustomCommandSummarySubscriber;
@@ -21,7 +22,9 @@ final class CommandSummarySubscriberTest extends KernelTestCase
     {
         self::bootKernel();
 
-        self::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new CommandSummarySubscriber());
+        /** @var EventDispatcherInterface $eventDispatcher */
+        $eventDispatcher = self::$kernel->getContainer()->get('event_dispatcher');
+        $eventDispatcher->addSubscriber(new CommandSummarySubscriber());
 
         $this->executeConsoleCommand('service-command foo bar')
             ->assertSuccessful()
@@ -38,7 +41,9 @@ final class CommandSummarySubscriberTest extends KernelTestCase
     {
         self::bootKernel();
 
-        self::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new CustomCommandSummarySubscriber());
+        /** @var EventDispatcherInterface $eventDispatcher */
+        $eventDispatcher = self::$kernel->getContainer()->get('event_dispatcher');
+        $eventDispatcher->addSubscriber(new CustomCommandSummarySubscriber());
 
         $this->executeConsoleCommand('service-command foo bar')
             ->assertSuccessful()

--- a/tests/Unit/AutoNameTest.php
+++ b/tests/Unit/AutoNameTest.php
@@ -33,6 +33,7 @@ final class AutoNameTest extends TestCase
 
     /**
      * @test
+     *
      * @group legacy
      */
     public function can_use_traditional_naming_method(): void

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -19,6 +19,7 @@ final class ConfigureWithAttributesTest extends TestCase
 {
     /**
      * @test
+     *
      * @dataProvider attributeCommandProvider
      */
     public function parse_arguments_and_options(string $class): void

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -14,8 +14,6 @@ use Zenstruck\Console\Test\TestCommand;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @requires PHP 8
  */
 final class ConfigureWithAttributesTest extends TestCase
 {

--- a/tests/Unit/ConfigureWithDocblocksTest.php
+++ b/tests/Unit/ConfigureWithDocblocksTest.php
@@ -146,6 +146,7 @@ final class ConfigureWithDocblocksTest extends TestCase
 
     /**
      * @test
+     *
      * @group legacy
      */
     public function can_override_docblock_configuration_with_traditional_configuration(): void
@@ -158,6 +159,7 @@ final class ConfigureWithDocblocksTest extends TestCase
          * @command not:used:name
          *
          * @argument arg not used
+         *
          * @option option not used
          */
         $command = new class() extends DocblockCommand {
@@ -371,6 +373,7 @@ final class ConfigureWithDocblocksTest extends TestCase
 
         /**
          * @command my:command
+         *
          * @hidden
          */
         $command = new class() extends DocblockCommand {};
@@ -386,6 +389,7 @@ final class ConfigureWithDocblocksTest extends TestCase
     {
         /**
          * @command my:command
+         *
          * @hidden
          */
         $command = new class() extends DocblockCommand {};
@@ -405,6 +409,7 @@ final class ConfigureWithDocblocksTest extends TestCase
     {
         /**
          * @command aliased:command
+         *
          * @alias alias1
          * @alias alias2
          */
@@ -421,6 +426,7 @@ final class ConfigureWithDocblocksTest extends TestCase
     {
         /**
          * @command aliased:command
+         *
          * @alias alias1
          * @alias alias2
          */


### PR DESCRIPTION
The easy part of https://github.com/zenstruck/console-extra/issues/29

But how to handle GitHub Actions without php 7.4 ?
Maybe a new file in the .github-repo without php 7.4?
Or is is possible with options?