### PR TITLE
fix: autowiring non-service arguments

### DIFF
--- a/src/InvokableServiceCommand.php
+++ b/src/InvokableServiceCommand.php
@@ -49,7 +49,7 @@ abstract class InvokableServiceCommand extends Command implements ServiceSubscri
                             return null;
                         }
 
-                        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+                        if (!$type instanceof \ReflectionNamedType) {
                             return null;
                         }
 
@@ -67,11 +67,19 @@ abstract class InvokableServiceCommand extends Command implements ServiceSubscri
                             return null;
                         }
 
+                        if (!$supportsAttributes && $type->isBuiltin()) {
+                            return null;
+                        }
+
                         if (!$supportsAttributes) {
                             return $type->allowsNull() ? '?'.$name : $name;
                         }
 
                         $attributes = \array_map(static fn(\ReflectionAttribute $a) => $a->newInstance(), $parameter->getAttributes());
+
+                        if (!$attributes && $type->isBuiltin()) {
+                            return null; // an attribute (ie Autowire) is required for built-in types
+                        }
 
                         return new SubscribedService('invoke:'.$parameter->name, $name, $type->allowsNull(), $attributes); // @phpstan-ignore-line
                     },

--- a/tests/Fixture/Command/WithAttributesServiceCommand.php
+++ b/tests/Fixture/Command/WithAttributesServiceCommand.php
@@ -34,10 +34,14 @@ final class WithAttributesServiceCommand extends InvokableServiceCommand
         AnInterface $imp,
 
         #[Autowire('%kernel.environment%')]
-        string $env,
+        string $environment,
+
+        #[Autowire('%kernel.debug%')]
+        bool $debug,
     ): void {
         $io->comment('Imp1: '.$imp1->get());
         $io->comment('Imp2: '.$imp->get());
-        $io->comment('Env: '.$env);
+        $io->comment('Env: '.$environment);
+        $io->comment('Debug: '.\var_export($debug, true));
     }
 }

--- a/tests/Integration/WithAttributesServiceCommandTest.php
+++ b/tests/Integration/WithAttributesServiceCommandTest.php
@@ -39,6 +39,7 @@ final class WithAttributesServiceCommandTest extends KernelTestCase
             ->assertOutputContains('Imp1: implementation1')
             ->assertOutputContains('Imp2: implementation2')
             ->assertOutputContains('Env: test')
+            ->assertOutputContains('Debug: true')
         ;
     }
 }


### PR DESCRIPTION
Before this fix, the following didn't work:

```php
public function __invoke(
    #[Autowire('%kernel.debug%')]
    bool $debug,
)
```