### PR TITLE
fix: don't autowire `Option|Attribute`

### DIFF
--- a/src/InvokableServiceCommand.php
+++ b/src/InvokableServiceCommand.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Zenstruck\Console\Attribute\Argument;
+use Zenstruck\Console\Attribute\Option;
 
 /**
  * All the benefits of {@see Invokable} but also allows for auto-injection of
@@ -73,6 +75,10 @@ abstract class InvokableServiceCommand extends Command implements ServiceSubscri
 
                         if (!$supportsAttributes) {
                             return $type->allowsNull() ? '?'.$name : $name;
+                        }
+
+                        if ($parameter->getAttributes(Option::class) || $parameter->getAttributes(Argument::class)) {
+                            return null; // don't auto-inject options/arguments
                         }
 
                         $attributes = \array_map(static fn(\ReflectionAttribute $a) => $a->newInstance(), $parameter->getAttributes());

--- a/tests/Fixture/Command/WithAttributesServiceCommand.php
+++ b/tests/Fixture/Command/WithAttributesServiceCommand.php
@@ -14,6 +14,8 @@ namespace Zenstruck\Console\Tests\Fixture\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\Target;
+use Zenstruck\Console\Attribute\Argument;
+use Zenstruck\Console\ConfigureWithAttributes;
 use Zenstruck\Console\InvokableServiceCommand;
 use Zenstruck\Console\IO;
 use Zenstruck\Console\Tests\Fixture\Service\AnInterface;
@@ -24,6 +26,8 @@ use Zenstruck\Console\Tests\Fixture\Service\AnInterface;
 #[AsCommand('with-attributes-service-command')]
 final class WithAttributesServiceCommand extends InvokableServiceCommand
 {
+    use ConfigureWithAttributes;
+
     public function __invoke(
         IO $io,
 
@@ -38,10 +42,18 @@ final class WithAttributesServiceCommand extends InvokableServiceCommand
 
         #[Autowire('%kernel.debug%')]
         bool $debug,
+
+        #[Argument]
+        string $arg1,
+
+        #[Argument]
+        string $arg2,
     ): void {
         $io->comment('Imp1: '.$imp1->get());
         $io->comment('Imp2: '.$imp->get());
         $io->comment('Env: '.$environment);
         $io->comment('Debug: '.\var_export($debug, true));
+        $io->comment('Arg1: '.$arg1);
+        $io->comment('Arg2: '.$arg2);
     }
 }

--- a/tests/Integration/WithAttributesServiceCommandTest.php
+++ b/tests/Integration/WithAttributesServiceCommandTest.php
@@ -34,12 +34,14 @@ final class WithAttributesServiceCommandTest extends KernelTestCase
      */
     public function services_injected(): void
     {
-        $this->executeConsoleCommand('with-attributes-service-command')
+        $this->executeConsoleCommand('with-attributes-service-command foo bar')
             ->assertSuccessful()
             ->assertOutputContains('Imp1: implementation1')
             ->assertOutputContains('Imp2: implementation2')
             ->assertOutputContains('Env: test')
             ->assertOutputContains('Debug: true')
+            ->assertOutputContains('Arg1: foo')
+            ->assertOutputContains('Arg2: bar')
         ;
     }
 }


### PR DESCRIPTION
Fixes a bug introduced in #60 