### PR TITLE
Upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,26 @@ on:
 
 jobs:
   test:
-    uses: zenstruck/.github/.github/workflows/php-test-symfony.yml@main
+    name: PHP ${{ matrix.php }}, SF ${{ matrix.symfony }} - ${{ matrix.deps }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1, 8.2, 8.3 ]
+        deps: [highest]
+        symfony: [6.4.*, 7.0.*]
+        include:
+          - php: 8.1
+            deps: lowest
+            symfony: '*'
+        exclude:
+          - php: 8.1
+            symfony: 7.0.*
+    steps:
+      - uses: zenstruck/.github/actions/php-test-symfony@main
+        with:
+          php: ${{ matrix.php }}
+          symfony: ${{ matrix.symfony }}
+          deps: ${{ matrix.deps }}
 
   code-coverage:
     uses: zenstruck/.github/.github/workflows/php-coverage-codecov.yml@main
@@ -27,7 +46,7 @@ jobs:
     steps:
       - uses: zenstruck/.github@php-cs-fixer
         with:
-          php: 8.0
+          php: 8.1
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -206,10 +206,24 @@ use Zenstruck\Console\InvokableCommand;
 
 #[Argument('arg1', description: 'Argument 1 description', mode: InputArgument::REQUIRED)]
 #[Argument('arg2', description: 'Argument 1 description')]
+#[Argument('arg3', suggestions: ['suggestion1', 'suggestion2'])] // for auto-completion
+#[Argument('arg4', suggestions: 'suggestionsForArg4')] // use a method on the command to get suggestions
 #[Option('option1', description: 'Option 1 description')]
+#[Option('option2', suggestions: ['suggestion1', 'suggestion2'])] // for auto-completion
+#[Option('option3', suggestions: 'suggestionsForOption3')] // use a method on the command to get suggestions
 class MyCommand extends InvokableCommand
 {
     // ...
+
+    private function suggestionsForArg4(): array
+    {
+        return ['suggestion3', 'suggestion4'];
+    }
+
+    private function suggestionsForOption3(): array
+    {
+        return ['suggestion3', 'suggestion4'];
+    }
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -12,21 +12,24 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
-        "symfony/console": "^5.4|^6.0|^7.0",
+        "php": ">=8.1",
+        "symfony/console": "^6.4|^7.0",
         "symfony/deprecation-contracts": "^2.2|^3.0",
-        "symfony/string": "^5.4|^6.0|^7.0",
+        "symfony/string": "^6.4|^7.0",
         "zenstruck/callback": "^1.4.2"
     },
     "require-dev": {
         "phpdocumentor/reflection-docblock": "^5.2",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/phpunit-bridge": "^6.2|^7.0",
-        "symfony/process": "^5.4|^6.0|^7.0",
-        "symfony/var-dumper": "^5.4|^6.0|^7.0",
+        "symfony/process": "^6.4|^7.0",
+        "symfony/var-dumper": "^6.4|^7.0",
         "zenstruck/console-test": "^1.3"
+    },
+    "conflict": {
+        "symfony/service-contracts": "<3.2"
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/phpunit-bridge": "^6.2|^7.0",
         "symfony/process": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
-        "zenstruck/console-test": "^1.3"
+        "zenstruck/console-test": "^1.4"
     },
     "conflict": {
         "symfony/service-contracts": "<3.2"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": ">=8.1",
         "symfony/console": "^6.4|^7.0",
         "symfony/deprecation-contracts": "^2.2|^3.0",
-        "symfony/string": "^6.4|^7.0",
         "zenstruck/callback": "^1.4.2"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          failOnRisky="true"
          failOnWarning="true"
 >

--- a/src/Attribute/Argument.php
+++ b/src/Attribute/Argument.php
@@ -19,7 +19,7 @@ use function Symfony\Component\String\s;
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
-final class Argument
+class Argument
 {
     /**
      * @see InputArgument::__construct()
@@ -37,9 +37,9 @@ final class Argument
      *
      * @return mixed[]|null
      */
-    public static function parseParameter(\ReflectionParameter $parameter): ?array
+    final public static function parseParameter(\ReflectionParameter $parameter): ?array
     {
-        if (!$attributes = $parameter->getAttributes(self::class)) {
+        if (!$attributes = $parameter->getAttributes(self::class, \ReflectionAttribute::IS_INSTANCEOF)) {
             return null;
         }
 
@@ -82,7 +82,7 @@ final class Argument
      *
      * @return mixed[]
      */
-    public function values(): array
+    final public function values(): array
     {
         if (!$this->name) {
             throw new \LogicException(\sprintf('A $name is required when using %s as a command class attribute.', self::class));

--- a/src/Attribute/Argument.php
+++ b/src/Attribute/Argument.php
@@ -13,6 +13,8 @@ namespace Zenstruck\Console\Attribute;
 
 use Symfony\Component\Console\Input\InputArgument;
 
+use function Symfony\Component\String\s;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -47,6 +49,11 @@ final class Argument
 
         /** @var self $value */
         $value = $attributes[0]->newInstance();
+
+        if (!$value->name && $parameter->name !== s($parameter->name)->snake()->replace('_', '-')->toString()) {
+            trigger_deprecation('zenstruck/console-extra', '1.4', 'Argument names will default to kebab-case in 2.0. Specify the name in #[Argument] explicitly to remove this deprecation.');
+        }
+
         $value->name ??= $parameter->name;
 
         if ($value->mode) {

--- a/src/Attribute/Argument.php
+++ b/src/Attribute/Argument.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Console\Attribute;
 
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Input\InputArgument;
 
 use function Symfony\Component\String\s;
@@ -23,12 +25,15 @@ class Argument
 {
     /**
      * @see InputArgument::__construct()
+     *
+     * @param string[]|string $suggestions
      */
     public function __construct(
         public ?string $name = null,
         private ?int $mode = null,
         private string $description = '',
         private string|bool|int|float|array|null $default = null,
+        private array|string $suggestions = [],
     ) {
     }
 
@@ -37,7 +42,7 @@ class Argument
      *
      * @return mixed[]|null
      */
-    final public static function parseParameter(\ReflectionParameter $parameter): ?array
+    final public static function parseParameter(\ReflectionParameter $parameter, Command $command): ?array
     {
         if (!$attributes = $parameter->getAttributes(self::class, \ReflectionAttribute::IS_INSTANCEOF)) {
             return null;
@@ -74,7 +79,7 @@ class Argument
             $value->default = $parameter->getDefaultValue();
         }
 
-        return $value->values();
+        return $value->values($command);
     }
 
     /**
@@ -82,12 +87,22 @@ class Argument
      *
      * @return mixed[]
      */
-    final public function values(): array
+    final public function values(Command $command): array
     {
         if (!$this->name) {
             throw new \LogicException(\sprintf('A $name is required when using %s as a command class attribute.', self::class));
         }
 
-        return [$this->name, $this->mode, $this->description, $this->default];
+        $suggestions = $this->suggestions;
+
+        if (\is_string($suggestions)) {
+            $suggestions = \Closure::bind(
+                fn(CompletionInput $i) => $this->{$suggestions}($i),
+                $command,
+                $command,
+            );
+        }
+
+        return [$this->name, $this->mode, $this->description, $this->default, $suggestions];
     }
 }

--- a/src/Attribute/Option.php
+++ b/src/Attribute/Option.php
@@ -19,7 +19,7 @@ use function Symfony\Component\String\s;
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
-final class Option
+class Option
 {
     /**
      * @see InputOption::__construct()
@@ -38,9 +38,9 @@ final class Option
      *
      * @return mixed[]|null
      */
-    public static function parseParameter(\ReflectionParameter $parameter): ?array
+    final public static function parseParameter(\ReflectionParameter $parameter): ?array
     {
-        if (!$attributes = $parameter->getAttributes(self::class)) {
+        if (!$attributes = $parameter->getAttributes(self::class, \ReflectionAttribute::IS_INSTANCEOF)) {
             return null;
         }
 
@@ -69,7 +69,7 @@ final class Option
 
         $value->mode = match ($name) {
             'array' => InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
-            'bool' => \defined(InputOption::class.'::VALUE_NEGATABLE') && $parameter->allowsNull() ? InputOption::VALUE_NEGATABLE : InputOption::VALUE_NONE,
+            'bool' => $parameter->allowsNull() ? InputOption::VALUE_NEGATABLE : InputOption::VALUE_NONE,
             default => InputOption::VALUE_REQUIRED,
         };
 
@@ -85,7 +85,7 @@ final class Option
      *
      * @return mixed[]
      */
-    public function values(): array
+    final public function values(): array
     {
         if (!$this->name) {
             throw new \LogicException(\sprintf('A $name is required when using %s as a command class attribute.', self::class));

--- a/src/Attribute/Option.php
+++ b/src/Attribute/Option.php
@@ -13,6 +13,8 @@ namespace Zenstruck\Console\Attribute;
 
 use Symfony\Component\Console\Input\InputOption;
 
+use function Symfony\Component\String\s;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -48,6 +50,11 @@ final class Option
 
         /** @var self $value */
         $value = $attributes[0]->newInstance();
+
+        if (!$value->name && $parameter->name !== s($parameter->name)->snake()->replace('_', '-')->toString()) {
+            trigger_deprecation('zenstruck/console-extra', '1.4', 'Argument names will default to kebab-case in 2.0. Specify the name in #[Option] explicitly to remove this deprecation.');
+        }
+
         $value->name ??= $parameter->name;
 
         if ($value->mode) {

--- a/src/AutoName.php
+++ b/src/AutoName.php
@@ -19,6 +19,8 @@ use function Symfony\Component\String\u;
  * @example GenerateUserReportCommand => app:generate-user-report
  *
  * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @deprecated
  */
 trait AutoName
 {

--- a/src/Configuration/DocblockConfiguration.php
+++ b/src/Configuration/DocblockConfiguration.php
@@ -27,6 +27,8 @@ use function Symfony\Component\String\u;
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @template T of Command
+ *
+ * @deprecated
  */
 final class DocblockConfiguration
 {

--- a/src/ConfigureWithAttributes.php
+++ b/src/ConfigureWithAttributes.php
@@ -28,27 +28,27 @@ trait ConfigureWithAttributes
         $class = new \ReflectionClass($this);
 
         foreach ($class->getAttributes(Argument::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-            $this->addArgument(...$attribute->newInstance()->values());
+            $this->addArgument(...$attribute->newInstance()->values($this));
         }
 
         foreach ($class->getAttributes(Option::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-            $this->addOption(...$attribute->newInstance()->values());
+            $this->addOption(...$attribute->newInstance()->values($this));
         }
 
         try {
             $parameters = (new \ReflectionClass(static::class))->getMethod('__invoke')->getParameters();
-        } catch (\ReflectionException $e) {
+        } catch (\ReflectionException) {
             return; // not using Invokable
         }
 
         foreach ($parameters as $parameter) {
-            if ($args = Argument::parseParameter($parameter)) {
+            if ($args = Argument::parseParameter($parameter, $this)) {
                 $this->addArgument(...$args);
 
                 continue;
             }
 
-            if ($args = Option::parseParameter($parameter)) {
+            if ($args = Option::parseParameter($parameter, $this)) {
                 $this->addOption(...$args);
             }
         }

--- a/src/ConfigureWithAttributes.php
+++ b/src/ConfigureWithAttributes.php
@@ -21,6 +21,10 @@ trait ConfigureWithAttributes
 {
     protected function configure(): void
     {
+        if (InvokableCommand::class !== self::class && $this instanceof InvokableCommand) {
+            trigger_deprecation('zenstruck/console-extra', '1.4', 'You can safely remove "%s" from "%s".', __TRAIT__, $this::class);
+        }
+
         $class = new \ReflectionClass($this);
 
         foreach ($class->getAttributes(Argument::class) as $attribute) {

--- a/src/ConfigureWithAttributes.php
+++ b/src/ConfigureWithAttributes.php
@@ -21,17 +21,17 @@ trait ConfigureWithAttributes
 {
     protected function configure(): void
     {
-        if (InvokableCommand::class !== self::class && $this instanceof InvokableCommand) {
+        if (InvokableCommand::class !== self::class && $this instanceof InvokableCommand) { // @phpstan-ignore-line
             trigger_deprecation('zenstruck/console-extra', '1.4', 'You can safely remove "%s" from "%s".', __TRAIT__, $this::class);
         }
 
         $class = new \ReflectionClass($this);
 
-        foreach ($class->getAttributes(Argument::class) as $attribute) {
+        foreach ($class->getAttributes(Argument::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $this->addArgument(...$attribute->newInstance()->values());
         }
 
-        foreach ($class->getAttributes(Option::class) as $attribute) {
+        foreach ($class->getAttributes(Option::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $this->addOption(...$attribute->newInstance()->values());
         }
 

--- a/src/ConfigureWithDocblocks.php
+++ b/src/ConfigureWithDocblocks.php
@@ -53,6 +53,8 @@ use Zenstruck\Console\Configuration\DocblockConfiguration;
  * @command |app:my:command|alias1|alias2 arg1 ?arg2 arg3=default arg4="default with space" ?arg5[] --option1 --option2= --option3=default --option4="default with space" --o|option5[]
  *
  * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @deprecated
  */
 trait ConfigureWithDocblocks
 {

--- a/src/Invokable.php
+++ b/src/Invokable.php
@@ -45,6 +45,10 @@ trait Invokable
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
+        if (InvokableCommand::class !== self::class && $this instanceof InvokableCommand) {
+            trigger_deprecation('zenstruck/console-extra', '1.4', 'You can safely remove "%s" from "%s".', __TRAIT__, $this::class);
+        }
+
         $this->io = ($this->argumentFactories[IO::class] ?? static fn() => new IO($input, $output))($input, $output);
     }
 
@@ -124,7 +128,7 @@ trait Invokable
      *
      * @return array<\ReflectionParameter>
      */
-    final protected static function invokeParameters(): array
+    protected static function invokeParameters(): array
     {
         try {
             return (new \ReflectionClass(static::class))->getMethod('__invoke')->getParameters();

--- a/src/Invokable.php
+++ b/src/Invokable.php
@@ -132,7 +132,7 @@ trait Invokable
     {
         try {
             return (new \ReflectionClass(static::class))->getMethod('__invoke')->getParameters();
-        } catch (\ReflectionException $e) {
+        } catch (\ReflectionException) {
             throw new \LogicException(\sprintf('"%s" must implement __invoke() to use %s.', static::class, Invokable::class));
         }
     }

--- a/src/Invokable.php
+++ b/src/Invokable.php
@@ -45,7 +45,7 @@ trait Invokable
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
-        if (InvokableCommand::class !== self::class && $this instanceof InvokableCommand) {
+        if (InvokableCommand::class !== self::class && $this instanceof InvokableCommand) { // @phpstan-ignore-line
             trigger_deprecation('zenstruck/console-extra', '1.4', 'You can safely remove "%s" from "%s".', __TRAIT__, $this::class);
         }
 
@@ -77,7 +77,7 @@ trait Invokable
                 if (!$type || $type->isBuiltin()) {
                     $name = $parameter->name;
 
-                    if ($attr = $parameter->getAttributes(ConsoleArgument::class)[0] ?? $parameter->getAttributes(Option::class)[0] ?? null) {
+                    if ($attr = $parameter->getAttributes(ConsoleArgument::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? $parameter->getAttributes(Option::class)[0] ?? null) {
                         $name = $attr->newInstance()->name ?? $name;
                     }
 

--- a/src/Invokable.php
+++ b/src/Invokable.php
@@ -20,14 +20,6 @@ use Zenstruck\Console\Attribute\Argument as ConsoleArgument;
 use Zenstruck\Console\Attribute\Option;
 
 /**
- * Makes your command "invokable" to reduce boilerplate.
- *
- * Auto-injects the following objects into __invoke():
- *
- * @see IO
- * @see InputInterface the "real" input
- * @see OutputInterface the "real" output
- *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 trait Invokable
@@ -132,7 +124,7 @@ trait Invokable
      *
      * @return array<\ReflectionParameter>
      */
-    private static function invokeParameters(): array
+    final protected static function invokeParameters(): array
     {
         try {
             return (new \ReflectionClass(static::class))->getMethod('__invoke')->getParameters();

--- a/src/InvokableCommand.php
+++ b/src/InvokableCommand.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Console\Tests\Fixture\Command;
+namespace Zenstruck\Console;
 
-use Zenstruck\Console\InvokableCommand as BaseInvokableCommand;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Makes your command "invokable" to reduce boilerplate.
  *
- *  Auto-injects the following objects into __invoke():
+ * Auto-injects the following objects into __invoke():
  *
  * @see IO
  * @see InputInterface the "real" input
@@ -24,10 +24,7 @@ use Zenstruck\Console\InvokableCommand as BaseInvokableCommand;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-abstract class InvokableCommand extends BaseInvokableCommand
+abstract class InvokableCommand extends Command
 {
-    protected function configure(): void
-    {
-        $this->setName('invoke');
-    }
+    use ConfigureWithAttributes, Invokable;
 }

--- a/src/InvokableServiceCommand.php
+++ b/src/InvokableServiceCommand.php
@@ -63,7 +63,7 @@ abstract class InvokableServiceCommand extends InvokableCommand implements Servi
                             return null;
                         }
 
-                        if ($parameter->getAttributes(Option::class) || $parameter->getAttributes(Argument::class)) {
+                        if ($parameter->getAttributes(Option::class, \ReflectionAttribute::IS_INSTANCEOF) || $parameter->getAttributes(Argument::class, \ReflectionAttribute::IS_INSTANCEOF)) {
                             return null; // don't auto-inject options/arguments
                         }
 

--- a/src/InvokableServiceCommand.php
+++ b/src/InvokableServiceCommand.php
@@ -13,7 +13,6 @@ namespace Zenstruck\Console;
 
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\StyleInterface;
@@ -25,17 +24,15 @@ use Zenstruck\Console\Attribute\Argument;
 use Zenstruck\Console\Attribute\Option;
 
 /**
- * All the benefits of {@see Invokable} but also allows for auto-injection of
+ * All the benefits of {@see InvokableCommand} but also allows for auto-injection of
  * any service from your Symfony DI container. You can think of it as
  * "Invokable Service Controllers" (with 'controller.service_arguments') but
  * for commands. Instead of a "Request", you inject {@see IO}.
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-abstract class InvokableServiceCommand extends Command implements ServiceSubscriberInterface
+abstract class InvokableServiceCommand extends InvokableCommand implements ServiceSubscriberInterface
 {
-    use Invokable { execute as private invokableExecute; }
-
     private ContainerInterface $container;
 
     public static function getSubscribedServices(): array
@@ -106,7 +103,7 @@ abstract class InvokableServiceCommand extends Command implements ServiceSubscri
             $this->addArgumentFactory($serviceId, static fn() => $value);
         }
 
-        return $this->invokableExecute($input, $output);
+        return parent::execute($input, $output);
     }
 
     #[Required]

--- a/tests/Fixture/Attribute/CustomArgument.php
+++ b/tests/Fixture/Attribute/CustomArgument.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/console-extra package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Console\Tests\Fixture\Attribute;
+
+use Zenstruck\Console\Attribute\Argument;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+final class CustomArgument extends Argument
+{
+    public function __construct(
+        string $description = '',
+        ?string $name = null,
+        ?int $mode = null,
+        float|int|bool|array|string|null $default = null,
+    ) {
+        parent::__construct($name, $mode, $description, $default);
+    }
+}

--- a/tests/Fixture/Attribute/CustomOption.php
+++ b/tests/Fixture/Attribute/CustomOption.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/console-extra package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Console\Tests\Fixture\Attribute;
+
+use Zenstruck\Console\Attribute\Option;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+final class CustomOption extends Option
+{
+    public function __construct(
+        string $description = '',
+        ?string $name = null,
+        array|string|null $shortcut = null,
+        ?int $mode = null,
+        float|int|bool|array|string|null $default = null,
+    ) {
+        parent::__construct($name, $shortcut, $mode, $description, $default);
+    }
+}

--- a/tests/Fixture/Command/WithAttributesServiceCommand.php
+++ b/tests/Fixture/Command/WithAttributesServiceCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Zenstruck\Console\Attribute\Argument;
-use Zenstruck\Console\ConfigureWithAttributes;
 use Zenstruck\Console\InvokableServiceCommand;
 use Zenstruck\Console\IO;
 use Zenstruck\Console\Tests\Fixture\Service\AnInterface;
@@ -26,8 +25,6 @@ use Zenstruck\Console\Tests\Fixture\Service\AnInterface;
 #[AsCommand('with-attributes-service-command')]
 final class WithAttributesServiceCommand extends InvokableServiceCommand
 {
-    use ConfigureWithAttributes;
-
     public function __invoke(
         IO $io,
 

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -39,10 +39,7 @@ final class Kernel extends BaseKernel
     {
         $c->register(ServiceCommand::class)->setAutowired(true)->setAutoconfigured(true);
         $c->register(ServiceSubscriberTraitCommand::class)->setAutowired(true)->setAutoconfigured(true);
-
-        if (self::VERSION_ID >= 60200) {
-            $c->register(WithAttributesServiceCommand::class)->setAutowired(true)->setAutoconfigured(true);
-        }
+        $c->register(WithAttributesServiceCommand::class)->setAutowired(true)->setAutoconfigured(true);
 
         $c->register('imp1', Implementation1::class);
         $c->register('imp2', Implementation2::class);

--- a/tests/Integration/WithAttributesServiceCommandTest.php
+++ b/tests/Integration/WithAttributesServiceCommandTest.php
@@ -13,7 +13,6 @@ namespace Zenstruck\Console\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Console\Test\InteractsWithConsole;
-use Zenstruck\Console\Tests\Fixture\Kernel;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -21,13 +20,6 @@ use Zenstruck\Console\Tests\Fixture\Kernel;
 final class WithAttributesServiceCommandTest extends KernelTestCase
 {
     use InteractsWithConsole;
-
-    protected function setUp(): void
-    {
-        if (Kernel::VERSION_ID < 60200) {
-            $this->markTestSkipped('Requires Symfony 6.2+');
-        }
-    }
 
     /**
      * @test

--- a/tests/Unit/AutoNameTest.php
+++ b/tests/Unit/AutoNameTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Command\Command;
 use Zenstruck\Console\AutoName;
 use Zenstruck\Console\Tests\Fixture\Command\AutoNameCommand;
 use Zenstruck\Console\Tests\Fixture\Command\AutoNameNoPrefixCommand;
-use Zenstruck\Console\Tests\Fixture\Kernel;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -41,25 +40,6 @@ final class AutoNameTest extends TestCase
     {
         $this->assertSame('auto-name-no-prefix', AutoNameNoPrefixCommand::getDefaultName());
         $this->assertSame('auto-name-no-prefix', (new AutoNameNoPrefixCommand())->getName());
-    }
-
-    /**
-     * @test
-     */
-    public function can_use_traditional_naming_method(): void
-    {
-        if (Kernel::MAJOR_VERSION > 6) {
-            $this->markTestSkipped();
-        }
-
-        $command = new class() extends Command {
-            use AutoName;
-
-            protected static $defaultName = 'override';
-        };
-
-        $this->assertSame('override', $command::getDefaultName());
-        $this->assertSame('override', $command->getName());
     }
 
     /**

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Zenstruck\Console\Attribute\Argument;
 use Zenstruck\Console\Attribute\Option;
 use Zenstruck\Console\ConfigureWithAttributes;
-use Zenstruck\Console\Invokable;
+use Zenstruck\Console\InvokableCommand;
 use Zenstruck\Console\Test\TestCommand;
 
 /**
@@ -122,13 +122,8 @@ final class ConfigureWithAttributesTest extends TestCase
     public function negatable_parameter_attribute_options(): void
     {
         $command = TestCommand::for(
-            new class() extends Command {
-                use ConfigureWithAttributes, Invokable;
-
-                public static function getDefaultName(): ?string
-                {
-                    return 'command';
-                }
+            new class('command') extends InvokableCommand {
+                use ConfigureWithAttributes;
 
                 public function __invoke(
                     #[Option] ?bool $foo,
@@ -160,13 +155,8 @@ final class ConfigureWithAttributesTest extends TestCase
     public function can_customize_argument_and_option_names_via_parameter_attribute(): void
     {
         $command = TestCommand::for(
-            new class() extends Command {
-                use ConfigureWithAttributes, Invokable;
-
-                public static function getDefaultName(): ?string
-                {
-                    return 'command';
-                }
+            new class('command') extends InvokableCommand {
+                use ConfigureWithAttributes;
 
                 public function __invoke(
                     #[Argument('custom-foo')] ?string $foo,
@@ -199,13 +189,8 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', Argument::class));
 
-        new class() extends Command {
-            use ConfigureWithAttributes, Invokable;
-
-            public static function getDefaultName(): ?string
-            {
-                return 'command';
-            }
+        new class('command') extends InvokableCommand {
+            use ConfigureWithAttributes;
 
             public function __invoke(
                 #[Argument(mode: InputArgument::REQUIRED)] $foo,
@@ -222,13 +207,8 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', Argument::class));
 
-        new class() extends Command {
-            use ConfigureWithAttributes, Invokable;
-
-            public static function getDefaultName(): ?string
-            {
-                return 'command';
-            }
+        new class('command') extends InvokableCommand {
+            use ConfigureWithAttributes;
 
             public function __invoke(
                 #[Argument(default: true)] $foo,
@@ -245,13 +225,8 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', Option::class));
 
-        new class() extends Command {
-            use ConfigureWithAttributes, Invokable;
-
-            public static function getDefaultName(): ?string
-            {
-                return 'command';
-            }
+        new class('command') extends InvokableCommand {
+            use ConfigureWithAttributes;
 
             public function __invoke(
                 #[Option(mode: InputArgument::REQUIRED)] $foo,
@@ -268,13 +243,8 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', Option::class));
 
-        new class() extends Command {
-            use ConfigureWithAttributes, Invokable;
-
-            public static function getDefaultName(): ?string
-            {
-                return 'command';
-            }
+        new class('command') extends InvokableCommand {
+            use ConfigureWithAttributes;
 
             public function __invoke(
                 #[Option(default: true)] $foo,
@@ -291,13 +261,8 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(\sprintf('%s cannot be repeated when used as a parameter attribute.', Option::class));
 
-        new class() extends Command {
-            use ConfigureWithAttributes, Invokable;
-
-            public static function getDefaultName(): ?string
-            {
-                return 'command';
-            }
+        new class('command') extends InvokableCommand {
+            use ConfigureWithAttributes;
 
             public function __invoke(
                 #[Option]
@@ -316,13 +281,8 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(\sprintf('%s cannot be repeated when used as a parameter attribute.', Argument::class));
 
-        new class() extends Command {
-            use ConfigureWithAttributes, Invokable;
-
-            public static function getDefaultName(): ?string
-            {
-                return 'command';
-            }
+        new class('command') extends InvokableCommand {
+            use ConfigureWithAttributes;
 
             public function __invoke(
                 #[Argument]
@@ -340,13 +300,8 @@ final class ConfigureWithAttributesTest extends TestCase
     public function kebab_case_argument_deprecation(): void
     {
         $command = TestCommand::for(
-            new class() extends Command {
-                use ConfigureWithAttributes, Invokable;
-
-                public static function getDefaultName(): ?string
-                {
-                    return 'command';
-                }
+            new class('command') extends InvokableCommand {
+                use ConfigureWithAttributes;
 
                 public function __invoke(
                     #[Argument] string $fooBar,
@@ -369,13 +324,8 @@ final class ConfigureWithAttributesTest extends TestCase
     public function kebab_case_option_deprecation(): void
     {
         $command = TestCommand::for(
-            new class() extends Command {
-                use ConfigureWithAttributes, Invokable;
-
-                public static function getDefaultName(): ?string
-                {
-                    return 'command';
-                }
+            new class('command') extends InvokableCommand {
+                use ConfigureWithAttributes;
 
                 public function __invoke(
                     #[Option] string $fooBar,
@@ -405,9 +355,9 @@ class WithClassAttributesCommand extends Command
     use ConfigureWithAttributes;
 }
 
-class WithParameterAttributesCommand extends Command
+class WithParameterAttributesCommand extends InvokableCommand
 {
-    use ConfigureWithAttributes, Invokable;
+    use ConfigureWithAttributes;
 
     public function __invoke(
         #[Argument(description: 'First argument is required')]

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -123,8 +123,6 @@ final class ConfigureWithAttributesTest extends TestCase
     {
         $command = TestCommand::for(
             new class('command') extends InvokableCommand {
-                use ConfigureWithAttributes;
-
                 public function __invoke(
                     #[Option] ?bool $foo,
                 ): void {
@@ -156,8 +154,6 @@ final class ConfigureWithAttributesTest extends TestCase
     {
         $command = TestCommand::for(
             new class('command') extends InvokableCommand {
-                use ConfigureWithAttributes;
-
                 public function __invoke(
                     #[Argument('custom-foo')] ?string $foo,
                     #[Option('custom-bar')] bool $bar,
@@ -190,8 +186,6 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', Argument::class));
 
         new class('command') extends InvokableCommand {
-            use ConfigureWithAttributes;
-
             public function __invoke(
                 #[Argument(mode: InputArgument::REQUIRED)] $foo,
             ): void {
@@ -208,8 +202,6 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', Argument::class));
 
         new class('command') extends InvokableCommand {
-            use ConfigureWithAttributes;
-
             public function __invoke(
                 #[Argument(default: true)] $foo,
             ): void {
@@ -226,8 +218,6 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Cannot use $mode when using %s as a parameter attribute, this is inferred from the parameter\'s type.', Option::class));
 
         new class('command') extends InvokableCommand {
-            use ConfigureWithAttributes;
-
             public function __invoke(
                 #[Option(mode: InputArgument::REQUIRED)] $foo,
             ): void {
@@ -244,8 +234,6 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Cannot use $default when using %s as a parameter attribute, this is inferred from the parameter\'s default value.', Option::class));
 
         new class('command') extends InvokableCommand {
-            use ConfigureWithAttributes;
-
             public function __invoke(
                 #[Option(default: true)] $foo,
             ): void {
@@ -262,8 +250,6 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectExceptionMessage(\sprintf('%s cannot be repeated when used as a parameter attribute.', Option::class));
 
         new class('command') extends InvokableCommand {
-            use ConfigureWithAttributes;
-
             public function __invoke(
                 #[Option]
                 #[Option]
@@ -282,8 +268,6 @@ final class ConfigureWithAttributesTest extends TestCase
         $this->expectExceptionMessage(\sprintf('%s cannot be repeated when used as a parameter attribute.', Argument::class));
 
         new class('command') extends InvokableCommand {
-            use ConfigureWithAttributes;
-
             public function __invoke(
                 #[Argument]
                 #[Argument]
@@ -301,8 +285,6 @@ final class ConfigureWithAttributesTest extends TestCase
     {
         $command = TestCommand::for(
             new class('command') extends InvokableCommand {
-                use ConfigureWithAttributes;
-
                 public function __invoke(
                     #[Argument] string $fooBar,
                 ): void {
@@ -325,8 +307,6 @@ final class ConfigureWithAttributesTest extends TestCase
     {
         $command = TestCommand::for(
             new class('command') extends InvokableCommand {
-                use ConfigureWithAttributes;
-
                 public function __invoke(
                     #[Option] string $fooBar,
                 ): void {
@@ -338,6 +318,25 @@ final class ConfigureWithAttributesTest extends TestCase
         $command->execute('--fooBar=value')
             ->assertSuccessful()
             ->assertOutputContains('fooBar: value')
+        ;
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function direct_user_to_remove_trait_if_not_required(): void
+    {
+        TestCommand::for(
+            new class('command') extends InvokableCommand {
+                use ConfigureWithAttributes;
+
+                public function __invoke()
+                {
+                }
+            })
+            ->execute()
+            ->assertSuccessful()
         ;
     }
 }
@@ -357,8 +356,6 @@ class WithClassAttributesCommand extends Command
 
 class WithParameterAttributesCommand extends InvokableCommand
 {
-    use ConfigureWithAttributes;
-
     public function __invoke(
         #[Argument(description: 'First argument is required')]
         string $arg1,

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -332,6 +332,64 @@ final class ConfigureWithAttributesTest extends TestCase
             }
         };
     }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function kebab_case_argument_deprecation(): void
+    {
+        $command = TestCommand::for(
+            new class() extends Command {
+                use ConfigureWithAttributes, Invokable;
+
+                public static function getDefaultName(): ?string
+                {
+                    return 'command';
+                }
+
+                public function __invoke(
+                    #[Argument] string $fooBar,
+                ): void {
+                    $this->io()->comment('fooBar: '.$fooBar);
+                }
+            },
+        );
+
+        $command->execute('value')
+            ->assertSuccessful()
+            ->assertOutputContains('fooBar: value')
+        ;
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function kebab_case_option_deprecation(): void
+    {
+        $command = TestCommand::for(
+            new class() extends Command {
+                use ConfigureWithAttributes, Invokable;
+
+                public static function getDefaultName(): ?string
+                {
+                    return 'command';
+                }
+
+                public function __invoke(
+                    #[Option] string $fooBar,
+                ): void {
+                    $this->io()->comment('fooBar: '.$fooBar);
+                }
+            },
+        );
+
+        $command->execute('--fooBar=value')
+            ->assertSuccessful()
+            ->assertOutputContains('fooBar: value')
+        ;
+    }
 }
 
 #[Argument('arg1', InputArgument::REQUIRED, 'First argument is required')]

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -20,6 +20,8 @@ use Zenstruck\Console\Attribute\Option;
 use Zenstruck\Console\ConfigureWithAttributes;
 use Zenstruck\Console\InvokableCommand;
 use Zenstruck\Console\Test\TestCommand;
+use Zenstruck\Console\Tests\Fixture\Attribute\CustomArgument;
+use Zenstruck\Console\Tests\Fixture\Attribute\CustomOption;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -338,6 +340,25 @@ final class ConfigureWithAttributesTest extends TestCase
             ->execute()
             ->assertSuccessful()
         ;
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_custom_argument_and_option_attributes(): void
+    {
+        $command = new class('command') extends Command {
+            use ConfigureWithAttributes;
+
+            public function __invoke(
+                #[CustomArgument('arg description')] string $foo,
+                #[CustomOption('opt description')] bool $bar,
+            ) {
+            }
+        };
+
+        $this->assertSame('arg description', $command->getDefinition()->getArgument('foo')->getDescription());
+        $this->assertSame('opt description', $command->getDefinition()->getOption('bar')->getDescription());
     }
 }
 

--- a/tests/Unit/ConfigureWithAttributesTest.php
+++ b/tests/Unit/ConfigureWithAttributesTest.php
@@ -121,10 +121,6 @@ final class ConfigureWithAttributesTest extends TestCase
      */
     public function negatable_parameter_attribute_options(): void
     {
-        if (!\defined(InputOption::class.'::VALUE_NEGATABLE')) {
-            $this->markTestSkipped('Negatable arguments not available.');
-        }
-
         $command = TestCommand::for(
             new class() extends Command {
                 use ConfigureWithAttributes, Invokable;

--- a/tests/Unit/ConfigureWithDocblocksTest.php
+++ b/tests/Unit/ConfigureWithDocblocksTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Zenstruck\Console\Configuration\DocblockConfiguration;
 use Zenstruck\Console\Tests\Fixture\Command\AutoNameDocblockCommand;
 use Zenstruck\Console\Tests\Fixture\Command\DocblockCommand;
-use Zenstruck\Console\Tests\Fixture\Kernel;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -152,54 +151,6 @@ final class ConfigureWithDocblocksTest extends TestCase
         $this->assertSame('Fifth option is an array with a shortcut (-o)', $option->getDescription());
         $this->assertSame('o', $option->getShortcut());
         $this->assertTrue($option->isValueRequired());
-    }
-
-    /**
-     * @test
-     */
-    public function can_override_docblock_configuration_with_traditional_configuration(): void
-    {
-        if (Kernel::MAJOR_VERSION > 6) {
-            $this->markTestSkipped();
-        }
-
-        /**
-         * Not used description.
-         *
-         * Not used help.
-         *
-         * @command not:used:name
-         *
-         * @argument arg not used
-         * @option option not used
-         */
-        $command = new class() extends DocblockCommand {
-            protected static $defaultName = 'traditional:name';
-            protected static $defaultDescription = 'Traditional description';
-
-            protected function configure(): void
-            {
-                $this
-                    ->setDescription(self::$defaultDescription)
-                    ->setHelp('Traditional help')
-                    ->addArgument('t1')
-                    ->addOption('t2')
-                ;
-            }
-        };
-
-        if (DocblockConfiguration::supportsLazy()) {
-            // Symfony <5.3 does not have this feature
-            $this->assertSame('Traditional description', $command::getDefaultDescription());
-        }
-
-        $this->assertSame('traditional:name', $command::getDefaultName());
-        $this->assertSame('Traditional description', $command->getDescription());
-        $this->assertSame('Traditional help', $command->getHelp());
-        $this->assertTrue($command->getDefinition()->hasArgument('t1'));
-        $this->assertTrue($command->getDefinition()->hasOption('t2'));
-        $this->assertFalse($command->getDefinition()->hasArgument('arg'));
-        $this->assertFalse($command->getDefinition()->hasOption('option'));
     }
 
     /**

--- a/tests/Unit/InvokableTest.php
+++ b/tests/Unit/InvokableTest.php
@@ -263,4 +263,23 @@ final class InvokableTest extends TestCase
 
         $command->something();
     }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function direct_user_to_remove_trait_if_not_required(): void
+    {
+        TestCommand::for(
+            new class() extends InvokableCommand {
+                use Invokable;
+
+                public function __invoke()
+                {
+                }
+            })
+            ->execute()
+            ->assertSuccessful()
+        ;
+    }
 }

--- a/tests/Unit/RunsProcessesTest.php
+++ b/tests/Unit/RunsProcessesTest.php
@@ -13,7 +13,7 @@ namespace Zenstruck\Console\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
-use Zenstruck\Console\Invokable;
+use Zenstruck\Console\InvokableCommand;
 use Zenstruck\Console\RunsProcesses;
 use Zenstruck\Console\Test\TestCommand;
 use Zenstruck\Console\Tests\Fixture\Command\RunsProcessesCommand;
@@ -67,8 +67,8 @@ final class RunsProcessesTest extends TestCase
      */
     public function long_command_is_trimmed(): void
     {
-        $command = new class('name') extends Command {
-            use Invokable, RunsProcesses;
+        $command = new class('name') extends InvokableCommand {
+            use RunsProcesses;
 
             public function __invoke(): void
             {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/console-extra package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Filesystem\Filesystem;
+
+require __DIR__.'/../vendor/autoload.php';
+
+(new Filesystem())->remove(__DIR__.'/../var');


### PR DESCRIPTION
- [x] Require PHP 8.1+
- [x] Require Symfony 6.4+
- [x] ~deprecate injecting options/arguments w/o attribute~
- [x] #41
- [x] Add `abstract class InvokableCommand extends Command`
- [x] ~Deprecate `Invokable` trait (extend `InvokableCommand` instead)?~
- [x] ~Deprecate `ConfigureWithAttributes` trait (would be moved to `InvokableCommand`)?~
- [x] Have `InvokableCommand` use `ConfigureWithAttributes`
- [x] Update docs
- [x] #38

Closes #38